### PR TITLE
Fix duplicate scroll wheel handler

### DIFF
--- a/heron/lib/widgets/ToolbarBuilder.js
+++ b/heron/lib/widgets/ToolbarBuilder.js
@@ -310,7 +310,7 @@ Heron.widgets.ToolbarBuilder.defs = {
             iconCls: "icon-hand",
             enableToggle: true,
             pressed: true,
-            control: new OpenLayers.Control.Navigation(),
+            control: new OpenLayers.Control.Navigation({zoomWheelEnabled: false}),
             id: "pan",
             toggleGroup: "toolGroup"
         },


### PR DESCRIPTION
Jan-Willem van Aalst (OpenTopo) pointed out that one "roll" of the mouse
wheel changes the zoom level by two steps instead of one. This turned out
to be a bug in Heron MC, which I have reported here:
https://github.com/heron-mc/heron-mc/issues/459
Until this is permanently fixed upstream, this patch remedies the problem
for our specific situation (it's not a general fix for Heron MC).